### PR TITLE
Support the creation of reviewers when creating PRs

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -52,10 +52,12 @@ export class GitHubClient {
    * @param remote The name of the remote to use for checking PRs against.
    * @param stableBranch The base stable branch to base all PRs off of. Often
    *                     master, but might be develop.
+   * @param reviewers List of reviewers, which should be requested to review the
+   *                  PR.
    */
   public async ensurePrsExist(
       allBranches: string[], combinedBranch: string | undefined,
-      remote: string, stableBranch: string) {
+      remote: string, stableBranch: string, reviewers: string[]) {
     //const allBranches = combinedBranch ? sortedBranches.concat(combinedBranch) : sortedBranches;
     const octoClient = octo.client(readGHKey());
     // TODO: take remote name from `-r` value.
@@ -182,6 +184,12 @@ export class GitHubClient {
         base,
         body: `${newBody}`,
       });
+
+      if (reviewers.length > 0) {
+        process.stdout.write(`Requesting reviewers ${reviewers}...`);
+        await ghPr.createReviewRequestsAsync(reviewers);
+      }
+
       console.log(emoji.get('white_check_mark'));
     }, Promise.resolve());
   }


### PR DESCRIPTION

<pr-train-toc>

#### PR chain:
#2 (Refactor github PR code into GitHubClient class.)
#3 (Adds info command to get branch name of next and previous branch in train.)
#4 (Support a push and PR range to push instead of all.)
👉 #5 (Support the creation of reviewers when creating PRs) 👈 **YOU ARE HERE**
#7 (Supports single-commit rebasing.)

</pr-train-toc>