### PR TITLE
Fix TypeError: Cannot read property 'match' of null

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -269,10 +269,14 @@ function readGHKey(): string {
  * @return The updated body for the PR to use.
  */
 function upsertNavigationInBody(newNavigation: string, body: string): string {
-  if (body.match(/<pr-train-toc>/)) {
-    return body.replace(/<pr-train-toc>[^]*<\/pr-train-toc>/, newNavigation);
+  if (body) {
+    if (body.match(/<pr-train-toc>/)) {
+      return body.replace(/<pr-train-toc>[^]*<\/pr-train-toc>/, newNavigation);
+    } else {
+      return body + '\n' + newNavigation;
+    }
   } else {
-    return body + '\n' + newNavigation;
+    return newNavigation;
   }
 }
 


### PR DESCRIPTION
When commit has only TITLE `git pr-train create-prs` fails with
en error:
❌  An error occured. Was there a conflict perhaps?
error TypeError: Cannot read property 'match' of null