### PR TITLE
[RF-1785] Support a --draft option to create PRs as drafts.

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -54,10 +54,12 @@ export class GitHubClient {
    *                     master, but might be develop.
    * @param reviewers List of reviewers, which should be requested to review the
    *                  PR.
+   * @param draft If true, creates PRs as draft PRs.
    */
   public async ensurePrsExist(
       allBranches: string[], combinedBranch: string | undefined,
-      remote: string, stableBranch: string, reviewers: string[]) {
+      remote: string, stableBranch: string, reviewers: string[],
+      draft: boolean) {
     //const allBranches = combinedBranch ? sortedBranches.concat(combinedBranch) : sortedBranches;
     const octoClient = octo.client(readGHKey());
     // TODO: take remote name from `-r` value.
@@ -139,6 +141,7 @@ export class GitHubClient {
           base,
           title,
           body,
+          draft,
         };
         process.stdout.write(`Creating PR for branch "${branch}"...`);
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,11 +359,13 @@ class PRTrainClient {
    * @param remote The name of the remote to update PRs on.
    * @param stableBranch The stable branch PRs will merge into.
    * @param reviewers List of usernames to request review on the PR.
+   * @param draft Indicates if the PRs should be created as drafts.
    * @param rangeString Range of branches to create PRs for in the notation
    *                    <start>..<end> (inclusive.)
    */
   public async ensurePrsExist(remote: string, stableBranch: string,
-                              reviewers: string[], rangeString?: string) {
+                              reviewers: string[], draft: boolean,
+                              rangeString?: string) {
     const range = rangeString
         ? rangeStringToRange(rangeString)
         : [0, this.sortedTrainBranches.length];
@@ -372,7 +374,7 @@ class PRTrainClient {
     const gitHubClient = new GitHubClient(this.sg);
     await gitHubClient.ensurePrsExist(
         requestedBranches, this.combinedTrainBranch, remote,
-        stableBranch, reviewers);
+        stableBranch, reviewers, draft);
   }
 }
 
@@ -500,12 +502,14 @@ async function main() {
     range: string;
     remote: string;
     reviewers: string[];
+    draft: boolean;
   }
   program
       .command('create-prs')
       .description('Create GitHub PRs from your train branches')
       .option('--range <range>', 'Pushes only those branches in a range. Uses index..index notation. (e.g. 0..17)')
       .option('--reviewers <reviewers>', 'Comma separated list of reviewers to request review of the PR.', commaSeparatedList, [])
+      .option('--draft', 'Creates PRs as drafts if true.', false)
       .option('--stable-branch <branch>', 'The branch used for the PR train to merge into. Defaults to develop.', config.stableBranch)
       .option('--remote <remote>', 'Set remote to push to. Defaults to "origin"', DEFAULT_REMOTE)
       .action(async (options: CreatePrsCommandOptions) => {
@@ -514,7 +518,7 @@ async function main() {
         await prTrainClient.printBranchesInTrain();
         await prTrainClient.ensurePrsExist(
             options.remote, options.stableBranch, options.reviewers,
-            options.range);
+            options.draft, options.range);
       });
 
 


### PR DESCRIPTION
This doesn't update existing PRs, only for new PRs.