### PR TITLE
Allow train identifiers without branches listed in it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-pr-train",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A tool to help manage PR chains",
   "main": "./index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ async function getBranchesConfigInCurrentTrain(
     return null;
   }
   const key = Object.keys(trains).find(trainKey => {
-    const branches = trains[trainKey];
+    const branches = trains[trainKey] || [];
     const branchNames = branches.map(b => getBranchName(b));
     return branchNames.indexOf(currentBranch) >= 0;
   });


### PR DESCRIPTION
This is helpful when you already merged all the branches, but not the identifier itself. It could happen if you work on a long-lived epic, and you merge train, and want to re-use identifier instead of creating a new one + commenting out the old one (yes, I keep all the trains in my config for stats purposes).

Without the fix this would fail:
```
just-bugs:
    #- bug/rf-1111/bug1
    #- bug/rf-8888/bug2
```