### PR TITLE
[RF-2423] Support no-confirmation with create-prs command.

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -54,12 +54,13 @@ export class GitHubClient {
    *                     master, but might be develop.
    * @param reviewers List of reviewers, which should be requested to review the
    *                  PR.
+   * @param assumeYes Does not ask for confirmation to create and update.
    * @param draft If true, creates PRs as draft PRs.
    */
   public async ensurePrsExist(
       allBranches: string[], combinedBranch: string | undefined,
       remote: string, stableBranch: string, reviewers: string[],
-      draft: boolean) {
+      assumeYes: boolean, draft: boolean) {
     //const allBranches = combinedBranch ? sortedBranches.concat(combinedBranch) : sortedBranches;
     const octoClient = octo.client(readGHKey());
     // TODO: take remote name from `-r` value.
@@ -96,10 +97,12 @@ export class GitHubClient {
       console.log(`  -> ${branch.green} (${title.italic})`);
     }, Promise.resolve());
 
-    console.log();
-    if (!(await promptly.confirm(colors.bold('Shall we do this? [y/n] ')))) {
-      console.log('No worries. Bye now.', emoji.get('wave'));
-      process.exit(0);
+    if (!assumeYes) {
+      console.log();
+      if (!(await promptly.confirm(colors.bold('Shall we do this? [y/n] ')))) {
+        console.log('No worries. Bye now.', emoji.get('wave'));
+        process.exit(0);
+      }
     }
 
     const nickAndRepoMatch = remoteUrl.match(/github\.com[/:](.*)\.git/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,13 +359,14 @@ class PRTrainClient {
    * @param remote The name of the remote to update PRs on.
    * @param stableBranch The stable branch PRs will merge into.
    * @param reviewers List of usernames to request review on the PR.
+   * @param assumeYes Does not ask for confirmation to create and update.
    * @param draft Indicates if the PRs should be created as drafts.
    * @param rangeString Range of branches to create PRs for in the notation
    *                    <start>..<end> (inclusive.)
    */
   public async ensurePrsExist(remote: string, stableBranch: string,
-                              reviewers: string[], draft: boolean,
-                              rangeString?: string) {
+                              reviewers: string[], assumeYes: boolean,
+                              draft: boolean, rangeString?: string) {
     const range = rangeString
         ? rangeStringToRange(rangeString)
         : [0, this.sortedTrainBranches.length];
@@ -374,7 +375,7 @@ class PRTrainClient {
     const gitHubClient = new GitHubClient(this.sg);
     await gitHubClient.ensurePrsExist(
         requestedBranches, this.combinedTrainBranch, remote,
-        stableBranch, reviewers, draft);
+        stableBranch, reviewers, assumeYes, draft);
   }
 }
 
@@ -502,6 +503,7 @@ async function main() {
     range: string;
     remote: string;
     reviewers: string[];
+    assumeYes: boolean;
     draft: boolean;
   }
   program
@@ -509,6 +511,7 @@ async function main() {
       .description('Create GitHub PRs from your train branches')
       .option('--range <range>', 'Pushes only those branches in a range. Uses index..index notation. (e.g. 0..17)')
       .option('--reviewers <reviewers>', 'Comma separated list of reviewers to request review of the PR.', commaSeparatedList, [])
+      .option('-y, --yes, --assume-yes', 'Creates and updates PRs without confirmation.')
       .option('--draft', 'Creates PRs as drafts if true.', false)
       .option('--stable-branch <branch>', 'The branch used for the PR train to merge into. Defaults to develop.', config.stableBranch)
       .option('--remote <remote>', 'Set remote to push to. Defaults to "origin"', DEFAULT_REMOTE)
@@ -518,7 +521,7 @@ async function main() {
         await prTrainClient.printBranchesInTrain();
         await prTrainClient.ensurePrsExist(
             options.remote, options.stableBranch, options.reviewers,
-            options.draft, options.range);
+            options.assumeYes, options.draft, options.range);
       });
 
 


### PR DESCRIPTION
The request to confirm creation of PRs is annoying for me, so I'd like to automatically approve, since there are no cases I want to re-review the PR creation, since PRs are cheap. This supports `git pr-train create-prs -y` or `git pr-train create-prs --yes` or `git-pr-train create-prs --assume-yes` to bypass the confirmation.

These flags were modeled off of `apt-get install`'s similar flags